### PR TITLE
[lugbot-test] Upgrade workspace plugin version to 3.4.8

### DIFF
--- a/.liferay/lugbot.yaml
+++ b/.liferay/lugbot.yaml
@@ -1,28 +1,16 @@
 tasks:
+  mode: pr
+  quality:
+    categories:
+    - name: BugPrevention
+    - name: Performance
   upgrade:
     currentVersion: '6.2'
-    plugins:
-    - evp-portlet
-    pluginsSDKPath: liferay-plugins-sdk-6.2-ee-sp20/
     upgradeVersion: '7.3'
     upgrades:
-    #- name: plugins-create-modules
-    #- name: plugins-convert-build
-    #- name: plugins-migrate-code
-    #- name: remove-legacy-files
-    #- name: update-service-builder-modules
-    #- name: upgrade-workspace-version
-    #- name: use-target-platform
-    #- name: use-release-api
-    #- name: auto-correct-breaking-changes
-    #- name: find-breaking-changes
-     - name: upgrade-portal-properties
-       params:
-         properties:
-         - liferay-workspace/configs/dev/portal-ext.properties
-         - liferay-workspace/configs/local/portal-ext.properties
-         - liferay-workspace/configs/prod/portal-ext.properties
-         - liferay-workspace/configs/uat/portal-ext.properties
-         - liferay-workspace/modules/evp/evp-portlet/src/main/java/portal.properties
-    #- name: cfg-to-config-file
+    - name: upgrade-workspace-version
+    - name: use-target-platform
+    - name: use-release-api
+    - name: auto-correct-breaking-changes
+    - name: find-breaking-changes
     workspacePath: liferay-workspace/

--- a/liferay-workspace/settings.gradle
+++ b/liferay-workspace/settings.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "3.4.2"
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.workspace", version: "3.4.8"
 		classpath group: "net.saliman", name: "gradle-properties-plugin", version: "1.4.6"
 	}
 


### PR DESCRIPTION
### Lugbot has created this PR to upgrade workspace plugin version to latest.
![merge advice](https://img.shields.io/badge/merge%20advice-recommended-orange)

<p>A new version of Liferay Workspace Gradle plugin is available. This change updates the gradle build to use this new version. Sometimes additional changes are necessasry to take full advantage of the new features in this new plugin version. Please consult the plugin’s https://github.com/liferay/liferay-portal/blob/master/modules/sdk/gradle-plugins-workspace/README.markdown and https://github.com/liferay/liferay-portal/blob/master/modules/sdk/gradle-plugins-workspace/CHANGELOG.markdown to see additional information related to this new version.</p> 

---

:information_source: The upgrades provided in this PR will not be tried again until the branch refs/heads/lugbot_upgrade-workspace-version_UpgradeWorkspacePluginVersion is deleted.