### PR TITLE
[lugbot-test] Use workspace product key: dxp-7.3-sp1 and update all build.gradle files to use dependency management.

### DIFF
--- a/.liferay/lugbot.yaml
+++ b/.liferay/lugbot.yaml
@@ -1,28 +1,16 @@
 tasks:
+  mode: pr
+  quality:
+    categories:
+    - name: BugPrevention
+    - name: Performance
   upgrade:
     currentVersion: '6.2'
-    plugins:
-    - evp-portlet
-    pluginsSDKPath: liferay-plugins-sdk-6.2-ee-sp20/
     upgradeVersion: '7.3'
     upgrades:
-    #- name: plugins-create-modules
-    #- name: plugins-convert-build
-    #- name: plugins-migrate-code
-    #- name: remove-legacy-files
-    #- name: update-service-builder-modules
-    #- name: upgrade-workspace-version
-    #- name: use-target-platform
-    #- name: use-release-api
-    #- name: auto-correct-breaking-changes
-    #- name: find-breaking-changes
-     - name: upgrade-portal-properties
-       params:
-         properties:
-         - liferay-workspace/configs/dev/portal-ext.properties
-         - liferay-workspace/configs/local/portal-ext.properties
-         - liferay-workspace/configs/prod/portal-ext.properties
-         - liferay-workspace/configs/uat/portal-ext.properties
-         - liferay-workspace/modules/evp/evp-portlet/src/main/java/portal.properties
-    #- name: cfg-to-config-file
+    - name: upgrade-workspace-version
+    - name: use-target-platform
+    - name: use-release-api
+    - name: auto-correct-breaking-changes
+    - name: find-breaking-changes
     workspacePath: liferay-workspace/

--- a/liferay-workspace/modules/evp/evp-portlet/build.gradle
+++ b/liferay-workspace/modules/evp/evp-portlet/build.gradle
@@ -18,18 +18,18 @@ dependencies {
 	cssBuilder group: "com.liferay", name: "com.liferay.css.builder", version: "3.0.2"
 
 	portalCommonCSS group: "com.liferay", name: "com.liferay.frontend.css.common"
-	compile group: "org.apache.xmlbeans", name: "xmlbeans", version: "2.6.0"
-	compile group: "commons-logging", name: "commons-logging", version: "1.1.3"
-	compile group: "log4j", name: "log4j", version: "1.2.17"
+	compile group: "org.apache.xmlbeans", name: "xmlbeans"
+	compile group: "commons-logging", name: "commons-logging"
+	compile group: "log4j", name: "log4j"
 	compile group: "com.liferay.portal", name: "com.liferay.util.bridges"
 	compile group: "com.liferay.portal", name: "com.liferay.util.java"
-	compile group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "5.3.5"
-	compile group: "dom4j", name: "dom4j", version: "1.6.1"
-	compile group: "javax.servlet.jsp.jstl", name: "jstl-api", version: "1.2"
-	compile group: "org.glassfish.web", name: "jstl-impl", version: "1.2"
-	compile group: "org.apache.poi", name: "poi", version: "3.9"
-	compile group: "org.apache.poi", name: "poi-ooxml", version: "3.9"
-	compile group: "org.apache.poi", name: "poi-ooxml-schemas", version: "3.9"
+	compile group: "com.liferay.portal", name: "com.liferay.util.taglib"
+	compile group: "dom4j", name: "dom4j"
+	compile group: "javax.servlet.jsp.jstl", name: "jstl-api"
+	compile group: "org.glassfish.web", name: "jstl-impl"
+	compile group: "org.apache.poi", name: "poi"
+	compile group: "org.apache.poi", name: "poi-ooxml"
+	compile group: "org.apache.poi", name: "poi-ooxml-schemas"
 	compile rootProject.files("libs/stax-api.jar")
 	compileOnly project(":modules:evp:evp-api")
 


### PR DESCRIPTION
### Lugbot has created this PR to adopt workspace product key and target platform dependency management.
![merge advice](https://img.shields.io/badge/merge%20advice-recommended-orange)

<p>Use target platform. TBD…</p> 

---

:information_source: The upgrades provided in this PR will not be tried again until the branch refs/heads/lugbot_use-target-platform_UseTargetPlatform is deleted.